### PR TITLE
Add GPS compass Android application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Gradle
+.gradle/
+build/
+**/build/
+
+# Android Studio
+.idea/
+*.iml
+.cache/
+local.properties
+.DS_Store
+
+# Generated files
+captures/
+output.json

--- a/README.md
+++ b/README.md
@@ -1,5 +1,47 @@
-# hellow-world
-first time
-i really love this game 
-i am not really understand how to use it yet.
-but i think i can figure it out .
+# GPS Compass Android App
+
+This project contains a simple Android application that shows live GPS data with a compass interface. It is written in Kotlin and uses the Android Jetpack libraries.
+
+## Features
+
+- Compass dial that renders the current travel direction (0°–359°) calculated from the latest two GPS fixes.
+- Heading value shown both in the center of the compass and as text below the dial.
+- Live altitude and speed readings with unit conversions.
+- Timestamp that displays how many seconds ago the latest GPS fix was received.
+- Settings screen that lets you choose altitude units (meters/feet), speed units (km/h, mph, m/s, knots), and switch between popular languages (system default, English, 简体中文, Español, Français, हिन्दी).
+- Runtime location permission handling and graceful feedback while waiting for GPS.
+
+## Project structure
+
+The repository follows the standard Android Gradle layout:
+
+```
+hellow-world/
+├── app/
+│   ├── build.gradle.kts
+│   ├── src/main/java/com/example/gpstracker/
+│   ├── src/main/res/
+│   └── ...
+├── build.gradle.kts
+├── gradle.properties
+└── settings.gradle.kts
+```
+
+## Building the APK
+
+1. Open the project in **Android Studio Flamingo (or newer)**.
+2. Let Android Studio download the Android Gradle Plugin and synchronize the project. The IDE will generate any missing Gradle wrapper files automatically.
+3. Connect an Android device or start an emulator.
+4. Use **Build ▸ Make Project** to compile, then **Build ▸ Build Bundle(s) / APK(s) ▸ Build APK(s)** to produce an installable APK located under `app/build/outputs/apk/`.
+
+Alternatively, once the Gradle wrapper has been generated, you can assemble a debug APK from the command line:
+
+```bash
+./gradlew assembleDebug
+```
+
+The resulting APK can be found at `app/build/outputs/apk/debug/app-debug.apk`.
+
+## Permissions
+
+The app requests `ACCESS_FINE_LOCATION` at runtime. You must grant this permission so that the compass heading, altitude, and speed can update using real GPS data.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,54 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.example.gpstracker"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.gpstracker"
+        minSdk = 26
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        getByName("release") {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        viewBinding = true
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.appcompat:appcompat:1.6.1")
+    implementation("com.google.android.material:material:1.11.0")
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    implementation("androidx.preference:preference-ktx:1.2.1")
+
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,3 @@
+# Add project specific ProGuard rules here.
+# By default, the flags in this file are appended to the global ProGuard rules
+# that are applied to your project.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
+    <application
+        android:allowBackup="true"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
+        android:icon="@drawable/ic_launcher_foreground"
+        android:label="@string/app_name"
+        android:roundIcon="@drawable/ic_launcher_foreground"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.GPSCompass">
+        <activity
+            android:name="com.example.gpstracker.SettingsActivity"
+            android:exported="false"
+            android:parentActivityName="com.example.gpstracker.MainActivity" />
+        <activity
+            android:name="com.example.gpstracker.MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/example/gpstracker/CompassView.kt
+++ b/app/src/main/java/com/example/gpstracker/CompassView.kt
@@ -1,0 +1,109 @@
+package com.example.gpstracker
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.util.AttributeSet
+import android.view.View
+import androidx.core.content.ContextCompat
+import kotlin.math.cos
+import kotlin.math.min
+import kotlin.math.sin
+
+class CompassView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : View(context, attrs, defStyleAttr) {
+
+    private val circlePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        strokeWidth = resources.displayMetrics.density * 3
+        color = ContextCompat.getColor(context, R.color.compassStroke)
+    }
+
+    private val tickPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        strokeWidth = resources.displayMetrics.density * 2
+        color = ContextCompat.getColor(context, R.color.compassTick)
+    }
+
+    private val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = ContextCompat.getColor(context, R.color.compassText)
+        textSize = resources.displayMetrics.scaledDensity * 16
+        textAlign = Paint.Align.CENTER
+    }
+
+    private val headingPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = ContextCompat.getColor(context, R.color.compassHeading)
+        strokeWidth = resources.displayMetrics.density * 4
+        style = Paint.Style.STROKE
+        strokeCap = Paint.Cap.ROUND
+    }
+
+    private val headingTextPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = ContextCompat.getColor(context, R.color.compassHeading)
+        textSize = resources.displayMetrics.scaledDensity * 32
+        textAlign = Paint.Align.CENTER
+        style = Paint.Style.FILL
+    }
+
+    private var heading: Float = 0f
+
+    fun setHeading(value: Float) {
+        heading = (value % 360 + 360) % 360
+        invalidate()
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        val width = width - paddingLeft - paddingRight
+        val height = height - paddingTop - paddingBottom
+        val radius = min(width, height) / 2f
+        val centerX = paddingLeft + width / 2f
+        val centerY = paddingTop + height / 2f
+
+        canvas.drawCircle(centerX, centerY, radius, circlePaint)
+
+        drawTicks(canvas, centerX, centerY, radius)
+        drawPointer(canvas, centerX, centerY, radius)
+        drawHeadingText(canvas, centerX, centerY)
+    }
+
+    private fun drawTicks(canvas: Canvas, cx: Float, cy: Float, radius: Float) {
+        val longTickLength = radius * 0.12f
+        val shortTickLength = radius * 0.07f
+        for (degree in 0 until 360 step 10) {
+            val angle = Math.toRadians(degree.toDouble() - 90)
+            val cosValue = cos(angle)
+            val sinValue = sin(angle)
+            val startRadius = radius - if (degree % 30 == 0) longTickLength else shortTickLength
+            val startX = cx + startRadius * cosValue.toFloat()
+            val startY = cy + startRadius * sinValue.toFloat()
+            val endX = cx + radius * cosValue.toFloat()
+            val endY = cy + radius * sinValue.toFloat()
+            canvas.drawLine(startX, startY, endX, endY, tickPaint)
+
+            if (degree % 90 == 0) {
+                val labelRadius = radius - longTickLength - textPaint.textSize
+                val textX = cx + labelRadius * cosValue.toFloat()
+                val textY = cy + labelRadius * sinValue.toFloat() - (textPaint.descent() + textPaint.ascent()) / 2
+                canvas.drawText(degree.toString(), textX, textY, textPaint)
+            }
+        }
+    }
+
+    private fun drawPointer(canvas: Canvas, cx: Float, cy: Float, radius: Float) {
+        canvas.save()
+        canvas.translate(cx, cy)
+        canvas.rotate(heading)
+        canvas.drawLine(0f, 0f, 0f, -radius + radius * 0.15f, headingPaint)
+        canvas.drawCircle(0f, 0f, radius * 0.06f, headingPaint)
+        canvas.restore()
+    }
+
+    private fun drawHeadingText(canvas: Canvas, cx: Float, cy: Float) {
+        val text = String.format("%d°", heading.toInt())
+        val y = cy - (headingTextPaint.descent() + headingTextPaint.ascent()) / 2
+        canvas.drawText(text, cx, y, headingTextPaint)
+    }
+}

--- a/app/src/main/java/com/example/gpstracker/MainActivity.kt
+++ b/app/src/main/java/com/example/gpstracker/MainActivity.kt
@@ -1,0 +1,225 @@
+package com.example.gpstracker
+
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.SharedPreferences
+import android.location.Location
+import android.location.LocationListener
+import android.location.LocationManager
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.view.Menu
+import android.view.MenuItem
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import androidx.preference.PreferenceManager
+import com.example.gpstracker.databinding.ActivityMainBinding
+import com.example.gpstracker.util.LanguageUtils
+import com.example.gpstracker.util.UnitFormatter
+import java.util.concurrent.TimeUnit
+
+class MainActivity : AppCompatActivity(), LocationListener {
+
+    private lateinit var binding: ActivityMainBinding
+    private lateinit var locationManager: LocationManager
+    private lateinit var sharedPreferences: SharedPreferences
+
+    private var previousLocation: Location? = null
+    private var lastLocation: Location? = null
+    private var lastFixTimestamp: Long = 0L
+    private var currentHeading: Float = 0f
+
+    private val handler = Handler(Looper.getMainLooper())
+    private val fixUpdateRunnable = object : Runnable {
+        override fun run() {
+            updateFixAge()
+            handler.postDelayed(this, UPDATE_INTERVAL_MS)
+        }
+    }
+
+    private val requestPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            if (granted) {
+                startLocationUpdates()
+            } else {
+                Toast.makeText(this, R.string.permission_denied, Toast.LENGTH_LONG).show()
+            }
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
+        sharedPreferences.registerOnSharedPreferenceChangeListener(preferenceChangeListener)
+        val language = sharedPreferences.getString(SettingsActivity.LANGUAGE_KEY, PREF_LANGUAGE_SYSTEM) ?: PREF_LANGUAGE_SYSTEM
+        LanguageUtils.applyLanguagePreference(language)
+
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        setSupportActionBar(binding.toolbar)
+
+        locationManager = getSystemService(LOCATION_SERVICE) as LocationManager
+    }
+
+    override fun onStart() {
+        super.onStart()
+        handler.post(fixUpdateRunnable)
+        if (hasLocationPermission()) {
+            startLocationUpdates()
+        } else {
+            requestLocationPermission()
+        }
+    }
+
+    override fun onStop() {
+        super.onStop()
+        handler.removeCallbacks(fixUpdateRunnable)
+        stopLocationUpdates()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        if (::sharedPreferences.isInitialized) {
+            sharedPreferences.unregisterOnSharedPreferenceChangeListener(preferenceChangeListener)
+        }
+    }
+
+    private fun hasLocationPermission(): Boolean {
+        return ContextCompat.checkSelfPermission(
+            this,
+            Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun requestLocationPermission() {
+        if (shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_FINE_LOCATION)) {
+            Toast.makeText(this, R.string.permission_rationale, Toast.LENGTH_LONG).show()
+        }
+        requestPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+    }
+
+    private fun startLocationUpdates() {
+        try {
+            if (!locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)) {
+                Toast.makeText(this, R.string.last_fix_unknown, Toast.LENGTH_SHORT).show()
+            }
+            locationManager.requestLocationUpdates(
+                LocationManager.GPS_PROVIDER,
+                MIN_TIME_BW_UPDATES,
+                MIN_DISTANCE_CHANGE_FOR_UPDATES,
+                this
+            )
+            locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER)?.let { lastKnown ->
+                previousLocation = null
+                lastLocation = lastKnown
+                lastFixTimestamp = System.currentTimeMillis()
+                currentHeading = if (lastKnown.hasBearing()) lastKnown.bearing else currentHeading
+                updateHeading()
+                updateMetrics(lastKnown)
+                updateFixAge()
+            }
+        } catch (ex: SecurityException) {
+            // Permission is checked before calling this method.
+        }
+    }
+
+    private fun stopLocationUpdates() {
+        try {
+            locationManager.removeUpdates(this)
+        } catch (_: SecurityException) {
+        }
+    }
+
+    override fun onLocationChanged(location: Location) {
+        previousLocation = lastLocation
+        lastLocation = location
+        lastFixTimestamp = System.currentTimeMillis()
+
+        updateHeading()
+        updateMetrics(location)
+        updateFixAge()
+    }
+
+    private fun updateHeading() {
+        val current = lastLocation ?: return
+        val previous = previousLocation
+        val bearing = when {
+            previous != null -> previous.bearingTo(current)
+            current.hasBearing() -> current.bearing
+            else -> currentHeading
+        }
+        val heading = (bearing + 360f) % 360f
+        currentHeading = heading
+        val headingInt = heading.toInt()
+        binding.directionValue.text = getString(R.string.direction_value_format, headingInt)
+        binding.compassView.setHeading(heading)
+    }
+
+    private fun updateMetrics(location: Location?) {
+        if (location == null) {
+            binding.altitudeValue.text = getString(R.string.value_placeholder)
+            binding.speedValue.text = getString(R.string.value_placeholder)
+            return
+        }
+        val altitudeUnit = sharedPreferences.getString(PREF_ALTITUDE_UNIT, DEFAULT_ALTITUDE_UNIT) ?: DEFAULT_ALTITUDE_UNIT
+        val speedUnit = sharedPreferences.getString(PREF_SPEED_UNIT, DEFAULT_SPEED_UNIT) ?: DEFAULT_SPEED_UNIT
+
+        binding.altitudeValue.text = UnitFormatter.formatAltitude(this, location.altitude, altitudeUnit)
+        binding.speedValue.text = UnitFormatter.formatSpeed(this, location.speed, speedUnit)
+    }
+
+    private fun updateFixAge() {
+        if (lastFixTimestamp == 0L) {
+            binding.lastFixValue.text = getString(R.string.last_fix_unknown)
+            return
+        }
+        val elapsedMillis = System.currentTimeMillis() - lastFixTimestamp
+        val safeElapsed = if (elapsedMillis < 0) 0L else elapsedMillis
+        val seconds = TimeUnit.MILLISECONDS.toSeconds(safeElapsed).coerceAtMost(MAX_FIX_AGE_SECONDS)
+        binding.lastFixValue.text = getString(R.string.last_fix_value_format, seconds)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.menu_main, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.action_settings -> {
+                startActivity(Intent(this, SettingsActivity::class.java))
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    override fun onProviderEnabled(provider: String) {}
+    override fun onProviderDisabled(provider: String) {}
+    override fun onStatusChanged(provider: String?, status: Int, extras: Bundle?) {}
+
+    private val preferenceChangeListener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+        if (key == PREF_ALTITUDE_UNIT || key == PREF_SPEED_UNIT) {
+            updateMetrics(lastLocation)
+        } else if (key == SettingsActivity.LANGUAGE_KEY) {
+            val language = sharedPreferences.getString(SettingsActivity.LANGUAGE_KEY, PREF_LANGUAGE_SYSTEM) ?: PREF_LANGUAGE_SYSTEM
+            LanguageUtils.applyLanguagePreference(language)
+        }
+    }
+
+    companion object {
+        private const val MIN_TIME_BW_UPDATES = 1000L
+        private const val MIN_DISTANCE_CHANGE_FOR_UPDATES = 0f
+        private const val UPDATE_INTERVAL_MS = 1000L
+        private const val MAX_FIX_AGE_SECONDS = 9999L
+
+        const val PREF_ALTITUDE_UNIT = "altitude_unit"
+        const val PREF_SPEED_UNIT = "speed_unit"
+        const val DEFAULT_ALTITUDE_UNIT = "meters"
+        const val DEFAULT_SPEED_UNIT = "kmh"
+        const val PREF_LANGUAGE_SYSTEM = "system"
+    }
+}

--- a/app/src/main/java/com/example/gpstracker/SettingsActivity.kt
+++ b/app/src/main/java/com/example/gpstracker/SettingsActivity.kt
@@ -1,0 +1,55 @@
+package com.example.gpstracker
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.preference.ListPreference
+import androidx.preference.PreferenceFragmentCompat
+import com.example.gpstracker.util.LanguageUtils
+
+class SettingsActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.settings_activity)
+        setSupportActionBar(findViewById(R.id.settingsToolbar))
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        if (savedInstanceState == null) {
+            supportFragmentManager
+                .beginTransaction()
+                .replace(R.id.settingsContainer, SettingsFragment())
+                .commit()
+        }
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        onBackPressedDispatcher.onBackPressed()
+        return true
+    }
+
+    class SettingsFragment : PreferenceFragmentCompat() {
+        override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+            setPreferencesFromResource(R.xml.root_preferences, rootKey)
+            configureUnitPreferences()
+            configureLanguagePreference()
+        }
+
+        private fun configureUnitPreferences() {
+            findPreference<ListPreference>(MainActivity.PREF_ALTITUDE_UNIT)?.summaryProvider = ListPreference.SimpleSummaryProvider.getInstance()
+            findPreference<ListPreference>(MainActivity.PREF_SPEED_UNIT)?.summaryProvider = ListPreference.SimpleSummaryProvider.getInstance()
+        }
+
+        private fun configureLanguagePreference() {
+            val languagePreference = findPreference<ListPreference>(LANGUAGE_KEY) ?: return
+            languagePreference.summaryProvider = ListPreference.SimpleSummaryProvider.getInstance()
+            languagePreference.setOnPreferenceChangeListener { _, newValue ->
+                LanguageUtils.applyLanguagePreference(newValue as String)
+                true
+            }
+        }
+    }
+
+    companion object {
+        const val LANGUAGE_KEY = "language"
+    }
+}

--- a/app/src/main/java/com/example/gpstracker/util/LanguageUtils.kt
+++ b/app/src/main/java/com/example/gpstracker/util/LanguageUtils.kt
@@ -1,0 +1,14 @@
+package com.example.gpstracker.util
+
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
+
+object LanguageUtils {
+    fun applyLanguagePreference(language: String) {
+        val locales = when (language) {
+            "system" -> LocaleListCompat.getEmptyLocaleList()
+            else -> LocaleListCompat.forLanguageTags(language)
+        }
+        AppCompatDelegate.setApplicationLocales(locales)
+    }
+}

--- a/app/src/main/java/com/example/gpstracker/util/UnitFormatter.kt
+++ b/app/src/main/java/com/example/gpstracker/util/UnitFormatter.kt
@@ -1,0 +1,38 @@
+package com.example.gpstracker.util
+
+import android.content.Context
+import com.example.gpstracker.R
+
+object UnitFormatter {
+
+    fun formatAltitude(context: Context, altitudeMeters: Double, unit: String): String {
+        val (value, unitLabelRes) = when (unit) {
+            "feet" -> altitudeMeters * METERS_TO_FEET to R.string.unit_feet
+            else -> altitudeMeters to R.string.unit_meters
+        }
+        return context.getString(
+            R.string.altitude_value_format,
+            value,
+            context.getString(unitLabelRes)
+        )
+    }
+
+    fun formatSpeed(context: Context, speedMetersPerSecond: Float, unit: String): String {
+        val (value, unitLabelRes) = when (unit) {
+            "mph" -> speedMetersPerSecond * MPS_TO_MPH to R.string.unit_mph
+            "mps" -> speedMetersPerSecond.toDouble() to R.string.unit_mps
+            "knots" -> speedMetersPerSecond * MPS_TO_KNOTS to R.string.unit_knots
+            else -> speedMetersPerSecond * MPS_TO_KMH to R.string.unit_kmh
+        }
+        return context.getString(
+            R.string.speed_value_format,
+            value,
+            context.getString(unitLabelRes)
+        )
+    }
+
+    private const val METERS_TO_FEET = 3.28084
+    private const val MPS_TO_KMH = 3.6
+    private const val MPS_TO_MPH = 2.23694
+    private const val MPS_TO_KNOTS = 1.94384
+}

--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#0057B8" />
+</shape>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <group android:translateX="27" android:translateY="27">
+        <path
+            android:fillColor="#FFFFFF"
+            android:pathData="M27,0a27,27 0 1,0 0,54a27,27 0 1,0 0,-54z" />
+        <path
+            android:fillColor="#0057B8"
+            android:pathData="M27,6a21,21 0 1,0 0,42a21,21 0 1,0 0,-42z" />
+        <path
+            android:fillColor="#FFFFFF"
+            android:pathData="M27,10a17,17 0 1,0 0,34a17,17 0 1,0 0,-34z" />
+        <path
+            android:fillColor="#0057B8"
+            android:pathData="M27,27l0,-15 2.5,5 5.5,10z" />
+    </group>
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorSurface"
+        android:theme="@style/ThemeOverlay.Material3.ActionBar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/app_name" />
+
+    <com.example.gpstracker.CompassView
+        android:id="@+id/compassView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_margin="16dp"
+        app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        app:layout_constraintBottom_toTopOf="@+id/directionLabel" />
+
+    <TextView
+        android:id="@+id/directionLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:text="@string/heading_label"
+        android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/compassView"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/directionValue"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/direction_value_placeholder"
+        android:textAppearance="@style/TextAppearance.Material3.DisplaySmall"
+        android:textStyle="bold"
+        app:layout_constraintTop_toBottomOf="@id/directionLabel"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/altitudeLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="@string/altitude_label"
+        android:textAppearance="@style/TextAppearance.Material3.TitleSmall"
+        app:layout_constraintTop_toBottomOf="@id/directionValue"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/altitudeValue"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/value_placeholder"
+        android:textAppearance="@style/TextAppearance.Material3.TitleLarge"
+        android:textStyle="bold"
+        app:layout_constraintTop_toBottomOf="@id/altitudeLabel"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/speedLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/speed_label"
+        android:textAppearance="@style/TextAppearance.Material3.TitleSmall"
+        app:layout_constraintTop_toBottomOf="@id/altitudeValue"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/speedValue"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/value_placeholder"
+        android:textAppearance="@style/TextAppearance.Material3.TitleLarge"
+        android:textStyle="bold"
+        app:layout_constraintTop_toBottomOf="@id/speedLabel"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/lastFixLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="@string/last_fix_label"
+        android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+        app:layout_constraintTop_toBottomOf="@id/speedValue"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/lastFixValue"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/last_fix_unknown"
+        android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+        app:layout_constraintTop_toBottomOf="@id/lastFixLabel"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintVertical_bias="0"
+        android:layout_marginBottom="16dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/settings_activity.xml
+++ b/app/src/main/res/layout/settings_activity.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/settingsToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorSurface"
+        android:theme="@style/ThemeOverlay.Material3.ActionBar"
+        app:title="@string/settings_title" />
+
+    <FrameLayout
+        android:id="@+id/settingsContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="?attr/actionBarSize"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_settings"
+        android:title="@string/menu_settings"
+        android:orderInCategory="100"
+        app:showAsAction="never" />
+</menu>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,34 @@
+<resources>
+    <string name="app_name">Brújula GPS</string>
+    <string name="heading_label">Rumbo</string>
+    <string name="direction_value_placeholder">0°</string>
+    <string name="direction_value_format">%1$d°</string>
+    <string name="altitude_label">Altitud</string>
+    <string name="speed_label">Velocidad</string>
+    <string name="last_fix_label">Última señal GPS</string>
+    <string name="last_fix_unknown">Esperando GPS…</string>
+    <string name="value_placeholder">--</string>
+    <string name="altitude_value_format">%1$.1f %2$s</string>
+    <string name="speed_value_format">%1$.1f %2$s</string>
+    <string name="last_fix_value_format">Hace %1$d s</string>
+    <string name="permission_rationale">Se necesita el permiso de ubicación para acceder al GPS.</string>
+    <string name="permission_denied">Permiso de ubicación denegado. Habilítalo en ajustes.</string>
+    <string name="menu_settings">Configuración</string>
+    <string name="settings_title">Configuración</string>
+    <string name="units_altitude_title">Unidades de altitud</string>
+    <string name="units_speed_title">Unidades de velocidad</string>
+    <string name="language_title">Idioma</string>
+    <string name="unit_meters">metros</string>
+    <string name="unit_feet">pies</string>
+    <string name="unit_kmh">km/h</string>
+    <string name="unit_mph">mph</string>
+    <string name="unit_mps">m/s</string>
+    <string name="unit_knots">nudos</string>
+    <string name="language_system_default">Predeterminado del sistema</string>
+    <string name="language_english">English</string>
+    <string name="language_chinese_simplified">简体中文</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_french">Français</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="compass_center_placeholder">0°</string>
+</resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,0 +1,34 @@
+<resources>
+    <string name="app_name">Boussole GPS</string>
+    <string name="heading_label">Cap</string>
+    <string name="direction_value_placeholder">0°</string>
+    <string name="direction_value_format">%1$d°</string>
+    <string name="altitude_label">Altitude</string>
+    <string name="speed_label">Vitesse</string>
+    <string name="last_fix_label">Dernière position GPS</string>
+    <string name="last_fix_unknown">En attente du GPS…</string>
+    <string name="value_placeholder">--</string>
+    <string name="altitude_value_format">%1$.1f %2$s</string>
+    <string name="speed_value_format">%1$.1f %2$s</string>
+    <string name="last_fix_value_format">Il y a %1$d s</string>
+    <string name="permission_rationale">L'autorisation de localisation est requise pour accéder au GPS.</string>
+    <string name="permission_denied">Autorisation de localisation refusée. Activez-la dans les paramètres.</string>
+    <string name="menu_settings">Paramètres</string>
+    <string name="settings_title">Paramètres</string>
+    <string name="units_altitude_title">Unités d'altitude</string>
+    <string name="units_speed_title">Unités de vitesse</string>
+    <string name="language_title">Langue</string>
+    <string name="unit_meters">mètres</string>
+    <string name="unit_feet">pieds</string>
+    <string name="unit_kmh">km/h</string>
+    <string name="unit_mph">mph</string>
+    <string name="unit_mps">m/s</string>
+    <string name="unit_knots">nœuds</string>
+    <string name="language_system_default">Langue du système</string>
+    <string name="language_english">English</string>
+    <string name="language_chinese_simplified">简体中文</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_french">Français</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="compass_center_placeholder">0°</string>
+</resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1,0 +1,34 @@
+<resources>
+    <string name="app_name">जीपीएस कंपास</string>
+    <string name="heading_label">दिशा</string>
+    <string name="direction_value_placeholder">0°</string>
+    <string name="direction_value_format">%1$d°</string>
+    <string name="altitude_label">ऊँचाई</string>
+    <string name="speed_label">गति</string>
+    <string name="last_fix_label">अंतिम GPS फिक्स</string>
+    <string name="last_fix_unknown">GPS की प्रतीक्षा…</string>
+    <string name="value_placeholder">--</string>
+    <string name="altitude_value_format">%1$.1f %2$s</string>
+    <string name="speed_value_format">%1$.1f %2$s</string>
+    <string name="last_fix_value_format">%1$d सेकंड पहले</string>
+    <string name="permission_rationale">GPS डेटा के लिए लोकेशन अनुमति आवश्यक है।</string>
+    <string name="permission_denied">लोकेशन अनुमति अस्वीकृत। कृपया सेटिंग्स में सक्षम करें।</string>
+    <string name="menu_settings">सेटिंग्स</string>
+    <string name="settings_title">सेटिंग्स</string>
+    <string name="units_altitude_title">ऊँचाई इकाइयाँ</string>
+    <string name="units_speed_title">गति इकाइयाँ</string>
+    <string name="language_title">भाषा</string>
+    <string name="unit_meters">मीटर</string>
+    <string name="unit_feet">फीट</string>
+    <string name="unit_kmh">किमी/घंटा</string>
+    <string name="unit_mph">मील/घंटा</string>
+    <string name="unit_mps">मीटर/सेकंड</string>
+    <string name="unit_knots">नॉट्स</string>
+    <string name="language_system_default">सिस्टम डिफ़ॉल्ट</string>
+    <string name="language_english">English</string>
+    <string name="language_chinese_simplified">简体中文</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_french">Français</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="compass_center_placeholder">0°</string>
+</resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,8 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.GPSCompass" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor">?attr/colorSurfaceVariant</item>
+        <item name="android:navigationBarColor">?attr/colorSurface</item>
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+</resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1,0 +1,34 @@
+<resources>
+    <string name="app_name">GPS罗盘</string>
+    <string name="heading_label">当前方向</string>
+    <string name="direction_value_placeholder">0°</string>
+    <string name="direction_value_format">%1$d°</string>
+    <string name="altitude_label">海拔</string>
+    <string name="speed_label">速度</string>
+    <string name="last_fix_label">上次定位</string>
+    <string name="last_fix_unknown">等待GPS…</string>
+    <string name="value_placeholder">--</string>
+    <string name="altitude_value_format">%1$.1f %2$s</string>
+    <string name="speed_value_format">%1$.1f %2$s</string>
+    <string name="last_fix_value_format">%1$d 秒前</string>
+    <string name="permission_rationale">需要定位权限以获取GPS数据。</string>
+    <string name="permission_denied">定位权限被拒绝，请在设置中开启。</string>
+    <string name="menu_settings">设置</string>
+    <string name="settings_title">设置</string>
+    <string name="units_altitude_title">海拔单位</string>
+    <string name="units_speed_title">速度单位</string>
+    <string name="language_title">语言</string>
+    <string name="unit_meters">米</string>
+    <string name="unit_feet">英尺</string>
+    <string name="unit_kmh">千米/小时</string>
+    <string name="unit_mph">英里/小时</string>
+    <string name="unit_mps">米/秒</string>
+    <string name="unit_knots">节</string>
+    <string name="language_system_default">跟随系统</string>
+    <string name="language_english">English</string>
+    <string name="language_chinese_simplified">简体中文</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_french">Français</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="compass_center_placeholder">0°</string>
+</resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,0 +1,40 @@
+<resources>
+    <string-array name="altitude_unit_entries">
+        <item>@string/unit_meters</item>
+        <item>@string/unit_feet</item>
+    </string-array>
+    <string-array name="altitude_unit_values">
+        <item>meters</item>
+        <item>feet</item>
+    </string-array>
+
+    <string-array name="speed_unit_entries">
+        <item>@string/unit_kmh</item>
+        <item>@string/unit_mph</item>
+        <item>@string/unit_mps</item>
+        <item>@string/unit_knots</item>
+    </string-array>
+    <string-array name="speed_unit_values">
+        <item>kmh</item>
+        <item>mph</item>
+        <item>mps</item>
+        <item>knots</item>
+    </string-array>
+
+    <string-array name="language_entries">
+        <item>@string/language_system_default</item>
+        <item>@string/language_english</item>
+        <item>@string/language_chinese_simplified</item>
+        <item>@string/language_spanish</item>
+        <item>@string/language_french</item>
+        <item>@string/language_hindi</item>
+    </string-array>
+    <string-array name="language_values">
+        <item>system</item>
+        <item>en</item>
+        <item>zh</item>
+        <item>es</item>
+        <item>fr</item>
+        <item>hi</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,6 @@
+<resources>
+    <color name="compassStroke">#607D8B</color>
+    <color name="compassTick">#90A4AE</color>
+    <color name="compassText">#546E7A</color>
+    <color name="compassHeading">#D32F2F</color>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,34 @@
+<resources>
+    <string name="app_name">GPS Compass</string>
+    <string name="heading_label">Heading</string>
+    <string name="direction_value_placeholder">0°</string>
+    <string name="direction_value_format">%1$d°</string>
+    <string name="altitude_label">Altitude</string>
+    <string name="speed_label">Speed</string>
+    <string name="last_fix_label">Last GPS fix</string>
+    <string name="last_fix_unknown">Waiting for GPS…</string>
+    <string name="value_placeholder">--</string>
+    <string name="altitude_value_format">%1$.1f %2$s</string>
+    <string name="speed_value_format">%1$.1f %2$s</string>
+    <string name="last_fix_value_format">%1$d s ago</string>
+    <string name="permission_rationale">Location permission is required to access GPS data.</string>
+    <string name="permission_denied">Location permission denied. Enable it in settings.</string>
+    <string name="menu_settings">Settings</string>
+    <string name="settings_title">Settings</string>
+    <string name="units_altitude_title">Altitude units</string>
+    <string name="units_speed_title">Speed units</string>
+    <string name="language_title">Language</string>
+    <string name="unit_meters">meters</string>
+    <string name="unit_feet">feet</string>
+    <string name="unit_kmh">km/h</string>
+    <string name="unit_mph">mph</string>
+    <string name="unit_mps">m/s</string>
+    <string name="unit_knots">knots</string>
+    <string name="language_system_default">System default</string>
+    <string name="language_english">English</string>
+    <string name="language_chinese_simplified">简体中文</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_french">Français</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="compass_center_placeholder">0°</string>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,8 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.GPSCompass" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
+        <item name="android:navigationBarColor">?attr/colorSurface</item>
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+</resources>

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <include domain="sharedpref" />
+</full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <include domain="sharedpref" />
+    </cloud-backup>
+    <device-transfer>
+        <include domain="sharedpref" />
+    </device-transfer>
+</data-extraction-rules>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <ListPreference
+        android:key="altitude_unit"
+        android:title="@string/units_altitude_title"
+        android:entries="@array/altitude_unit_entries"
+        android:entryValues="@array/altitude_unit_values"
+        android:defaultValue="meters" />
+
+    <ListPreference
+        android:key="speed_unit"
+        android:title="@string/units_speed_title"
+        android:entries="@array/speed_unit_entries"
+        android:entryValues="@array/speed_unit_values"
+        android:defaultValue="kmh" />
+
+    <ListPreference
+        android:key="language"
+        android:title="@string/language_title"
+        android:entries="@array/language_entries"
+        android:entryValues="@array/language_values"
+        android:defaultValue="system" />
+
+</PreferenceScreen>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,5 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+plugins {
+    id("com.android.application") version "8.2.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+android.nonTransitiveRClass=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "GPS Compass"
+include(":app")


### PR DESCRIPTION
## Summary
- add a Kotlin-based Android GPS compass app with live location updates and compass rendering
- implement settings for altitude/speed units and multi-language support with localized resources
- document project structure and build steps while adding Gradle configuration files

## Testing
- not run (Android tooling is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_690977449f848323956f556be63b5b46